### PR TITLE
Add fstype to mount arguments

### DIFF
--- a/tasks/log_volume.yml
+++ b/tasks/log_volume.yml
@@ -9,4 +9,5 @@
   mount:
     src: "{{ DALITE_LOG_DOWNLOAD_VOLUME_DEVICE_ID }}"
     name: "{{ DALITE_LOG_DOWNLOAD_USER_HOME }}"
+    fstype: "{{ DALITE_LOG_DOWNLOAD_VOLUME_FILESYSTEM }}"
     state: mounted


### PR DESCRIPTION
@pomegranited, review please. 🙂 Should be the last one. Missed an occasionally-required variable.
