### PR TITLE
Remove dependency on geerlingguy.nginx role.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,1 @@
-dependencies:
-  - name: geerlingguy.nginx
-    nginx_remove_default_vhost: true
+dependencies: []


### PR DESCRIPTION
We now install nginx via apt by default on all servers, so the role is not needed anymore.